### PR TITLE
Add fix for message on Photo extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.8
+* Fixed issue retrieving `photo` withouth permissions.
+
 ## 1.0.7
 * Fixed documentation issue.
 

--- a/ricloud/__init__.py
+++ b/ricloud/__init__.py
@@ -1,3 +1,3 @@
 """Various scripts for communicating with Reincubate's iCloud API"""
 
-__version__ = "1.0.7"
+__version__ = "1.0.8"

--- a/ricloud/sample_script.py
+++ b/ricloud/sample_script.py
@@ -78,8 +78,10 @@ def main():
 
     if 'photos' in data and isinstance(data['photos'], list):
         for photo in data['photos']:
-            with open(os.path.join('out', photo['filename']), 'wb') as out:
-                api.backup_client.download_file(device_id, photo['file_id'], out)
+            # It can get the "Contact enterprise" message, in which case we cannot access `filename`
+            if 'filename' in photo:
+                with open(os.path.join('out', photo['filename']), 'wb') as out:
+                    api.backup_client.download_file(device_id, photo['file_id'], out)
 
     print 'Complete! All data is in the directory "out".'
 


### PR DESCRIPTION
After extracting a data type, it can get the "Contact enterprise" message if the API Key doesn't have permission to access it, in which case the photo download will fail trying to get the `filename`.

This PR adds a fix for that, checking if `filename` is actually there.